### PR TITLE
Replace dots in field names with underscores

### DIFF
--- a/file_parser.py
+++ b/file_parser.py
@@ -22,7 +22,7 @@ def load_data(data_folder):
             # Specify properties for subject
             subject = {
                 "id": line[0],
-                line[0].split(':')[0]: line[0],
+                line[0].split(':')[0].replace('.', '_'): line[0],
                 "name": id_name_mapping[line[0]],
                 "type": id_type_mapping[line[0]]
             }
@@ -30,7 +30,7 @@ def load_data(data_folder):
             # Specify properties for object
             object_ = {
                 "id": line[2],
-                line[2].split(':')[0]: line[2],
+                line[2].split(':')[0].replace('.', '_'): line[2],
                 "name": id_name_mapping[line[2]],
                 "type": id_type_mapping[line[2]]
             }


### PR DESCRIPTION
BTE does not allow dots in field names, because dots are used when querying
nested fields. Therefore, replace dots with underscores in field names.